### PR TITLE
Fix RVineHessian sample size

### DIFF
--- a/R/RVineHessian.R
+++ b/R/RVineHessian.R
@@ -120,7 +120,7 @@ RVineHessian <- function(data, RVM) {
         stop("Copula family not implemented.")
 
     n <- d <- args$d
-    N <- T
+    N <- T <- args$n
 
     o <- diag(RVM$Matrix)
     if (any(o != length(o):1)) {

--- a/tests/testthat/test-RVineHessian.R
+++ b/tests/testthat/test-RVineHessian.R
@@ -1,0 +1,17 @@
+test_that("RVineHessian uses all observations", {
+    Matrix <- matrix(c(2, 1, 0, 1), 2, 2)
+    family <- par <- par2 <- matrix(0, 2, 2)
+    family[2, 1] <- 1
+    par[2, 1] <- 0.5
+    RVM <- RVineMatrix(Matrix, family, par, par2)
+    data <- matrix(c(0.1, 0.3, 0.7, 0.2, 0.8, 0.4), ncol = 2)
+
+    per_observation <- lapply(seq_len(nrow(data)), function(i) {
+        RVineHessian(data[i, ], RVM)$hessian
+    })
+
+    expect_equal(
+        RVineHessian(data, RVM)$hessian,
+        Reduce(`+`, per_observation)
+    )
+})


### PR DESCRIPTION
## Summary

- pass the preprocessed observation count to the `hesse` C routine
- add a regression test confirming that the full-data Hessian sums the per-observation Hessians

## Root cause and impact

`RVineHessian()` never assigned the sample size to `T`, so R resolved `T` to the base `TRUE` constant and the C routine processed one malformed pseudo-observation. The Hessian now uses every complete input observation.

## Validation

- `R CMD INSTALL --library=/tmp/vinecopula-lib .`
- `R_LIBS=/tmp/vinecopula-lib Rscript -e 'library(VineCopula); testthat::test_dir("tests/testthat", reporter = "summary")'`

Closes #99
